### PR TITLE
fix: no topbar on dark mode on account of color

### DIFF
--- a/src/pages/preferences.vue
+++ b/src/pages/preferences.vue
@@ -74,7 +74,7 @@ export default {
       location.reload()
     },
     switchColorScheme(mode) {
-      this.$store.commit('setColorScheme', mode)
+      this.$store.commit('SET_COLOR_SCHEME', mode)
     }
   }
 }

--- a/src/plugins/init.ts
+++ b/src/plugins/init.ts
@@ -47,9 +47,9 @@ export default (context: any) => {
 
     window.addEventListener('keydown', (e) => {
       if (e.shiftKey && e.key === 'L') {
-        store.commit('setColorScheme', 'light')
+        store.commit('SET_COLOR_SCHEME', 'light')
       } else if (e.shiftKey && e.key === 'D') {
-        store.commit('setColorScheme', 'dark')
+        store.commit('SET_COLOR_SCHEME', 'dark')
       }
     })
 

--- a/src/plugins/topbar.js
+++ b/src/plugins/topbar.js
@@ -52,15 +52,15 @@ const options = {
   barThickness: 2.5,
   barColors: {
     // '0': '#31A8FF',
-    '0': '#000',
+    '0': '#00B2FF',
     // '.25': 'rgba(52,  152, 219, .9)',
     // '.50': 'rgba(241, 196, 15,  .9)',
     // '.75': 'rgba(230, 126, 34,  .9)',
     // '1.0': '#305DFF'
-    '1.0': '#000'
+    '1.0': '#0057FF'
   },
   shadowBlur: 3,
-  shadowColor: 'rgba(0, 0, 0, 0.2)'
+  shadowColor: 'rgba(0, 0, 0, 0.3)'
 }
 const repaint = function() {
   canvas.width = window.innerWidth

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -42,7 +42,7 @@ export const mutations = {
   /**
    * @param {'light'|'dark'|'auto'} mode
    */
-  setColorScheme(state, mode) {
+  SET_COLOR_SCHEME(state, mode) {
     JSCookie.set('color_scheme', mode, { expires: 99999 })
     const colorSchemeClassName = getColorClassName(mode)
     state.colorSchemeClassName = colorSchemeClassName
@@ -74,6 +74,6 @@ export const actions = {
       req.headers && req.headers.cookie ? Cookie.parse(req.headers.cookie) : {}
     const mode = cookies.color_scheme
 
-    commit('setColorScheme', mode)
+    commit('SET_COLOR_SCHEME', mode)
   }
 }


### PR DESCRIPTION
This PR resolves #111

- Change topbar color to blue gradient to make it display well on both light mode and dark mode
- Change the mutation's name casing following naming convention